### PR TITLE
transform objects to pointers in encodeParse() fix #5

### DIFF
--- a/angular-parse.js
+++ b/angular-parse.js
@@ -280,17 +280,17 @@
       };
 
       Model.prototype.encodeParse = function() {
-        var key, obj, result, _i, _len, _ref;
+        var key, obj, result, _i, _len, _ref, _ref1;
         result = {};
         _ref = this.constructor.attributes;
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           key = _ref[_i];
           if (key in this) {
             obj = this[key];
-            if ((obj != null) && obj.objectId && obj.className) {
+            if ((obj != null) && obj.objectId && (obj.className || ((_ref1 = obj.constructor) != null ? _ref1.className : void 0))) {
               obj = {
                 __type: "Pointer",
-                className: obj.className,
+                className: obj.className || obj.constructor.className,
                 objectId: obj.objectId
               };
             }

--- a/angular-parse.js
+++ b/angular-parse.js
@@ -280,17 +280,17 @@
       };
 
       Model.prototype.encodeParse = function() {
-        var key, obj, result, _i, _len, _ref, _ref1;
+        var key, obj, result, _i, _len, _ref;
         result = {};
         _ref = this.constructor.attributes;
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           key = _ref[_i];
           if (key in this) {
             obj = this[key];
-            if ((obj != null) && obj.objectId && ((_ref1 = obj.constructor) != null ? _ref1.className : void 0)) {
+            if ((obj != null) && obj.objectId && obj.className) {
               obj = {
                 __type: "Pointer",
-                className: obj.constructor.className,
+                className: obj.className,
                 objectId: obj.objectId
               };
             }

--- a/src/angular-parse.coffee
+++ b/src/angular-parse.coffee
@@ -190,11 +190,11 @@ module.factory 'ParseModel', (ParseUtils) ->
         if key of this
           obj = @[key]
 
-          if obj? and obj.objectId and obj.constructor?.className
+          if obj? and obj.objectId and obj.className
             # Pointer
             obj = {
               __type: "Pointer"
-              className: obj.constructor.className
+              className: obj.className
               objectId: obj.objectId
             }
 

--- a/src/angular-parse.coffee
+++ b/src/angular-parse.coffee
@@ -190,11 +190,11 @@ module.factory 'ParseModel', (ParseUtils) ->
         if key of this
           obj = @[key]
 
-          if obj? and obj.objectId and obj.className
+          if obj? and obj.objectId and ( obj.className or obj.constructor?.className )
             # Pointer
             obj = {
               __type: "Pointer"
-              className: obj.className
+              className: obj.className or obj.constructor.className
               objectId: obj.objectId
             }
 


### PR DESCRIPTION
Code was already transforming objects to pointers, but was working properly: the `constructor`of a model did not have for me any `className`
